### PR TITLE
Do not follow symlinks from michealcadilhac

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -7,6 +7,10 @@
  #include <config.h>
 #endif
 
+#ifndef WIN32
+#define _GNU_SOURCE
+#endif
+
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdint.h>             /* uint32_t */
@@ -38,6 +42,8 @@
 #define BLOCK_PROTOCOL_SIGNATURE "529319a0-577f-4d6b-a6c3-3c20f56f290c"
 
 #define SEAF_PATH_MAX 4096
+
+#define S_ISREGORLNK(mode) (S_ISREG(mode) || S_ISLNK(mode))
 
 #ifndef ccnet_warning
 #define ccnet_warning(fmt, ...) g_warning("%s(%d): " fmt, __FILE__, __LINE__, ##__VA_ARGS__)

--- a/common/diff-simple.c
+++ b/common/diff-simple.c
@@ -62,8 +62,8 @@ inline static gboolean
 dirent_same (SeafDirent *denta, SeafDirent *dentb)
 {
     return (strcmp (dentb->id, denta->id) == 0 &&
-	    denta->mode == dentb->mode &&
-	    denta->mtime == dentb->mtime);
+            denta->mode == dentb->mode &&
+             denta->mtime == dentb->mtime);
 }
 
 static int
@@ -74,7 +74,7 @@ diff_files (int n, SeafDirent *dents[], const char *basedir, DiffOptions *opt)
 
     memset (files, 0, sizeof(files[0])*n);
     for (i = 0; i < n; ++i) {
-        if (dents[i] && S_ISREG(dents[i]->mode)) {
+        if (dents[i] && S_ISREGORLNK(dents[i]->mode)) {
             files[i] = dents[i];
             ++n_files;
         }

--- a/common/index/index.h
+++ b/common/index/index.h
@@ -286,7 +286,7 @@ static inline size_t ce_namelen(const struct cache_entry *ce)
 static inline unsigned int create_ce_mode(unsigned int mode)
 {
     if (S_ISLNK(mode))
-        return S_IFLNK;
+        return S_IFLNK | 0777;
     if (S_ISDIR(mode))
         return S_IFDIR;
     return S_IFREG | ce_permissions(mode);
@@ -312,7 +312,7 @@ static inline unsigned int canon_mode(unsigned int mode)
     if (S_ISREG(mode))
         return S_IFREG | ce_permissions(mode);
     if (S_ISLNK(mode))
-        return S_IFLNK;
+        return S_IFLNK | 0777;
     if (S_ISDIR(mode))
         return S_IFDIR;
     return S_IFGITLINK;

--- a/daemon/change-set.c
+++ b/daemon/change-set.c
@@ -277,7 +277,7 @@ update_file (ChangeSetDirent *dent,
              SeafStat *st,
              const char *modifier)
 {
-    if (!sha1 || !st || !S_ISREG(st->st_mode))
+    if (!sha1 || !st || !S_ISREGORLNK(st->st_mode))
         return;
     dent->mode = create_ce_mode(st->st_mode);
     dent->mtime = (gint64)st->st_mtime;
@@ -400,7 +400,7 @@ add_to_tree (ChangeSet *changeset,
                     seaf_dir_free (seaf_dir);
                 }
                 dir = dent->subdir;
-            } else if (S_ISREG(dent->mode)) {
+            } else if (S_ISREGORLNK(dent->mode)) {
                 if (i == (n-1)) {
                     /* File exists, update it. */
                     update_file (dent, sha1, st, modifier);
@@ -488,7 +488,7 @@ delete_from_tree (ChangeSet *changeset,
                 seaf_dir_free (seaf_dir);
             }
             dir = dent->subdir;
-        } else if (S_ISREG(dent->mode)) {
+        } else if (S_ISREGORLNK(dent->mode)) {
             if (i == (n-1)) {
                 /* Remove from hash table without freeing dent. */
                 remove_dent_from_dir (dir, dname);
@@ -705,7 +705,7 @@ changeset_check_path (ChangeSet *changeset,
                 break;
             }
             dir = dent->subdir;
-        } else if (S_ISREG(dent->mode)) {
+        } else if (S_ISREGORLNK(dent->mode)) {
             if (i == (n-1)) {
                 if (dent->mode != mode) {
                     seaf_message ("Changeset mismatch: %s mode mismatch, "

--- a/daemon/set-perm.c
+++ b/daemon/set-perm.c
@@ -299,7 +299,7 @@ seaf_set_path_permission (const char *path, SeafPathPerm perm, gboolean recursiv
     struct stat st;
     mode_t new_mode;
 
-    if (stat (path, &st) < 0) {
+    if (lstat (path, &st) < 0) {
         seaf_warning ("Failed to stat %s: %s\n", path, strerror(errno));
         return -1;
     }

--- a/daemon/vc-utils.c
+++ b/daemon/vc-utils.c
@@ -400,7 +400,7 @@ delete_path (const char *worktree, const char *name,
 
     if (!S_ISDIR(mode)) {
         /* file doesn't exist in work tree */
-        if (seaf_stat (path, &st) < 0 || !S_ISREG(st.st_mode)) {
+        if (seaf_stat (path, &st) < 0 || !S_ISREGORLNK(st.st_mode)) {
             return 0;
         }
 

--- a/daemon/wt-monitor-linux.c
+++ b/daemon/wt-monitor-linux.c
@@ -521,7 +521,7 @@ add_watch_recursive (RepoWatchInfo *info,
 
     full_path = g_build_filename (worktree, path, NULL);
 
-    if (stat (full_path, &st) < 0) {
+    if (lstat (full_path, &st) < 0) {
         seaf_warning ("[wt mon] fail to stat %s: %s\n", full_path, strerror(errno));
         goto out;
     }
@@ -563,11 +563,10 @@ add_watch_recursive (RepoWatchInfo *info,
              * Note that d_type may not be supported in some file systems,
              * in this case DT_UNKNOWN is returned.
              */
-            if (dent->d_type == DT_DIR || dent->d_type == DT_LNK ||
-                dent->d_type == DT_UNKNOWN)
+            if (dent->d_type == DT_DIR || dent->d_type == DT_UNKNOWN)
                 add_watch_recursive (info, in_fd, worktree, sub_path, add_events);
 
-            if (dent->d_type == DT_REG && add_events)
+            if ((dent->d_type == DT_REG || dent->d_type == DT_LNK) && add_events)
                 add_event_to_queue (info->status, WT_EVENT_CREATE_OR_UPDATE,
                                     sub_path, NULL);
             g_free (sub_path);

--- a/daemon/wt-monitor-macos.c
+++ b/daemon/wt-monitor-macos.c
@@ -141,7 +141,7 @@ process_one_event (const char* eventPath,
     /* Reinterpreted RENAMED as combine of CREATED or DELETED event */
     if (eventFlags & kFSEventStreamEventFlagItemRenamed) {
         seaf_debug ("Rename flag set for %s \n", filename);
-        if (stat (eventPath, &buf) < 0) {
+        if (lstat (eventPath, &buf) < 0) {
             /* ret = -1, file is gone */
             add_event_to_queue (status, WT_EVENT_DELETE, filename, NULL);
         } else {
@@ -152,14 +152,14 @@ process_one_event (const char* eventPath,
 
     if (eventFlags & kFSEventStreamEventFlagItemRemoved) {
         seaf_debug ("Deleted flag set for %s.\n", filename);
-        if (stat (eventPath, &buf) < 0) {
+        if (lstat (eventPath, &buf) < 0) {
             add_event_to_queue (status, WT_EVENT_DELETE, filename, NULL);
         }
     }
 
     if (eventFlags & kFSEventStreamEventFlagItemModified) {
         seaf_debug ("Modified flag set for %s.\n", filename);
-        if (stat (eventPath, &buf) == 0) {
+        if (lstat (eventPath, &buf) == 0) {
             add_event_to_queue (status, WT_EVENT_CREATE_OR_UPDATE, filename, NULL);
         }
     }
@@ -174,7 +174,7 @@ process_one_event (const char* eventPath,
           * kFSEventStreamEventFlagItemIsDir
           * kFSEventStreamEventFlagItemIsSymlink
           */
-        if (stat (eventPath, &buf) == 0) {
+        if (lstat (eventPath, &buf) == 0) {
             add_event_to_queue (status, WT_EVENT_CREATE_OR_UPDATE, filename, NULL);
         }
     }


### PR DESCRIPTION
This is implemented by:
1. Never following symlinks with stat, open, ...
2. When seaf_util_open is called on a symlink, a temporary file in memory is created with contents the target of the link.
3. When uploading a symlink, it is modified to look like a regular file, *BUT* 'modifier' is changed to '@modifier'.
4. When downloading a file that has a modifier of the form '@...', change its mode to symlink.  Next, when the file is created, this mode will be picked up, and a proper symlink will be created.

From the point of view of an unpatched daemon, links will look like regular files in 0644 that contain a path.